### PR TITLE
update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,13 @@
     "url": "https://github.com/maxcnunes/spawn-auto-restart"
   },
   "dependencies": {
-    "chokidar": "^1.2.0",
-    "debug": "^2.2.0"
+    "chokidar": "^3.4.2",
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "eslint": "^1.7.1"
+  },
+  "engines": {
+    "node": ">= 8.10.0"
   }
 }


### PR DESCRIPTION
Updates the dependendencies of spawn-auto-restart to the newest versions. Neither of them had their underlying signatures change, and so consumers of this module will not have to change anything, with the exception that moving to these means that node must be minimally 8.10 for chokidar and 6 for debug. However, this does mean that this module should be usable on node 14 which I believe would break under chokidar v1, and that the dependency tree of chokidar was greatly reduced in the v3 release which is a boon to everyone.

An upside to the changes here is that an `npm audit` report will get resolved for consumers of this module:
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ braces                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.3.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ spawn-auto-restart [dev]                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ spawn-auto-restart > chokidar > anymatch > micromatch >      │
│               │ braces                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/786                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
```